### PR TITLE
Fix Release by using admin token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
         id: semantic
         uses: cycjimmy/semantic-release-action@v4
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
         with:
           dry_run: ${{ github.event_name == 'pull_request' }}
       - name: Run GoReleaser

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,12 +12,14 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    name: Lint
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pre-commit
 
   test:
     runs-on: ubuntu-latest
+    name: Test
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
@@ -29,6 +31,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    name: Release
     outputs:
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
       new_release_published: ${{ steps.semantic.outputs.new_release_published }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,14 +3,6 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
-    "@semantic-release/github",
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "go.mod", "go.sum"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ]
+    "@semantic-release/github"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,0 @@
-# [0.1.0](https://github.com/armand-sauzay/note/compare/v0.0.1...v0.1.0) (2024-12-07)
-
-
-### Features
-
-* initial repository setup ([#1](https://github.com/armand-sauzay/note/issues/1)) ([7083f94](https://github.com/armand-sauzay/note/commit/7083f948bbb263dc7a0ea2d20b61c8c276718a2d))

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A modern terminal-based note-taking application built with [Bubble Tea](https://
 ### Using Homebrew (macOS & Linux)
 
 ```bash
-brew tap armandsauzay/note
+brew tap armandsauzay/homebrew-tap
 brew install note
 ```
 
@@ -38,7 +38,7 @@ go install github.com/armandsauzay/note@latest
 ```
 git clone https://github.com/armandsauzay/note.git
 cd note
-go install
+go install .
 ```
 
 ## 🚀 Usage


### PR DESCRIPTION

Because of branch protection rules, adding an admin token will be useful to push on the main branch
For now, deactivating the changelog (which is available in release notes so this issue does not happen again
