### PR TITLE
Create note and config folders if they don't exist

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -8,7 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-	"flag"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"


### PR DESCRIPTION
Fixes #4. 

Avoid start time error in case note or config folder does not exist by creating folders if they don't exist.
