### PR TITLE
Update Go module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module note
+module github.com/armand-sauzay/note
 
 go 1.21
 


### PR DESCRIPTION
Set the module name to the Github repository path.

Otherwise, `go install github.com/armand-sauzay/note@v0.1.2` fails with:

```
go: downloading github.com/armand-sauzay/note v0.1.2
go: github.com/armand-sauzay/note@v0.1.2: version constraints conflict:
        github.com/armand-sauzay/note@v0.1.2: parsing go.mod:
        module declares its path as: note
                but was required as: github.com/armand-sauzay/note
```