### PR TITLE
Add -info flag

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+
+// Print base notes path
+func printNotesDirPath() error {
+	cfg, err := LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Base notes path: \n \t %s \n", cfg.NotesDir)
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -531,11 +531,20 @@ func (m *Model) renderMarkdown(content string) string {
 func main() {
 	// Add version flag handling
 	versionFlag := flag.Bool("version", false, "Print version information")
+	infoFlag := flag.Bool("info", false, "Print note dir path")
 	flag.Parse()
 
 	// Check if version flag was provided
 	if *versionFlag {
 		printVersion()
+		os.Exit(0)
+	}
+
+	if *infoFlag {
+		err := printNotesDirPath()
+		if err != nil {
+			log.Fatal(err)
+		}
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
# Add -info flag for general information and configuration display

Add function to show base path of notes directory.

Probably should add something like cobra/viper to make this a little more standard but didn't want to do too much rewriting.

> There's no contributors guide so not sure how you like things formatted, kinda went barebones here. 


* Adding because I had to dig through source to figure out where the notes files were getting saved.