### PR TITLE
feat: Add CreateEmpty config option to create empty notes

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,6 +33,7 @@ type Config struct {
 		Light string `yaml:"light"`
 		Dark  string `yaml:"dark"`
 	} `yaml:"theme"`
+	CreateEmpty bool `yaml:"create_empty"`
 }
 
 type Dimensions struct {
@@ -102,6 +103,7 @@ func DefaultConfig() *Config {
 			Light: "default",
 			Dark:  "default",
 		},
+		CreateEmpty: false,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -189,9 +189,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			timestamp := time.Now().Format("2006-01-02-150405")
 			filename := filepath.Join(currentDir, fmt.Sprintf("note-%s.md", timestamp))
+			content := ""
 
-			content := fmt.Sprintf("# New Note\n\nCreated: %s\n",
-				time.Now().Format("2006-01-02 15:04:05"))
+			// If CreateEmpty is falsey, create a default content
+			if !m.config.CreateEmpty {
+				content = fmt.Sprintf("# New Note\n\nCreated: %s\n",
+					time.Now().Format("2006-01-02 15:04:05"))
+			}
 
 			if err := os.WriteFile(filename, []byte(content), 0644); err == nil {
 				m.updateNotes()


### PR DESCRIPTION
### Description

This PR introduces a new top-level boolean configuration option, `create_empty`, to control the initial content of new notes.

When `create_empty` is set to `true` in the config, new notes will be created with empty content. Otherwise we default to the existing behavior of creating notes with pre-populated note content.

### How to Test

1.  **Test Exisiting Behavior:** Remove `create_empty` or set it to `false` in the config yaml. Create a new note and verify it contains the default content.
2.  **Test New Feature:** Set `create_empty: true` in your config file. Create a new note and verify its content is empty.
